### PR TITLE
Added initial facebook messenger connection

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,25 @@
+class MessagesController < ApplicationController
+
+  def webhook
+    if params['hub.mode'] == 'subscribe' &&
+         params['hub.verify_token'] == ENV['FACEBOOK_MESSENGER_VERIFY_TOKEN']
+      render text: params['hub.challenge']
+    else
+      head :forbidden
+    end
+  end
+
+  def incoming
+    if params['object'] == 'page'
+      params['entry'].each do |entry|
+        if entry['messaging'][0]['message'] # TODO account for multiple messages
+          sender_id = entry['messaging'][0]['sender']['id']
+          text = entry['messaging'][0]['message']['text']
+          messenger_service = MessengerService.new(sender_id, text)
+          messenger_service.route_incoming
+        end
+      end
+    end
+    head :ok
+  end
+end

--- a/app/services/messenger_service.rb
+++ b/app/services/messenger_service.rb
@@ -1,0 +1,24 @@
+class MessengerService
+  RANDOM_NAME = ['Bob', 'Sally', 'Rock', 'Gemmy']
+
+  def initialize(sender_id, input)
+    @sender_id = sender_id
+    @input = input
+  end
+
+  def route_incoming
+    send_message(:free_the_uc_stones, {random_name: RANDOM_NAME.sample})
+  end
+
+  private
+
+  def send_message(message, data_hash={})
+    data = {
+        recipient: {id: @sender_id},
+        message: {text: I18n.t(message, data_hash)}
+    }.to_json
+    RestClient.post "https://graph.facebook.com/v2.6/me/messages?access_token=#{ENV['PAGE_ACCESS_TOKEN']}",
+                    data, content_type: :json
+  end
+
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,5 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  free_the_uc_stones: |
+    Help free %{random_name}! Free the UC Stones :)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'static#index'
+  get 'messages/webhook', to: 'messages#webhook'
+  post 'messages/webhook', to: 'messages#incoming'
 end


### PR DESCRIPTION
Added the GET `/messages/webhook` route for verifying that we do own letsthryve.com and added the POST `/messages/webhook` route for receiving incoming messages from Facebook.

Currently the bot only responds with a simple random message, but, this is a foundation for us to work off of.

@jeanineh Took care of adding the `FACEBOOK_MESSENGER_VERIFY_TOKEN` and `PAGE_ACCESS_TOKEN` environment variables to `.env.production` on the server as well as connecting our app in the Facebook developer console.
