### PR TITLE
Typing hints and message recovery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,5 @@ group :development do
   gem 'capistrano3-puma'
   gem 'capistrano3-nginx'
   gem 'capistrano-upload-config'
+  gem 'annotate'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
       tzinfo (~> 1.1)
     airbrussh (1.1.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    annotate (2.7.1)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 12.0)
     arel (7.1.4)
     builder (3.2.2)
     byebug (9.0.6)
@@ -190,6 +193,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   byebug
   capistrano (~> 3.6)
   capistrano-rails (~> 1.1)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,15 +13,8 @@ class MessagesController < ApplicationController
     if params['object'] == 'page'
       params['entry'].each do |entry|
         entry['messaging'].each do |item|
-          if item['optin']
-            route_optin(item)
-          elsif item['postback']
-            route_postback(item)
-          elsif item['message'] && item['message']['quick_reply']
-            route_postback(item, item['message']['quick_reply']['payload'])
-          elsif item['message']
-            route_text_message(item)
-          end
+          user = load_user(item['sender']['id'])
+          handle_incoming_item(user, item) unless user.ignore
         end
       end
     end
@@ -30,26 +23,36 @@ class MessagesController < ApplicationController
 
   private
 
-  def route_text_message(item)
-    user = item['sender']['id']
-    text = item['message']['text']
-    receiver = GetStartedReceiver.new(user, {text: text})
-    receiver.get_started
+  def handle_incoming_item(user, item)
+    if user.fb_profile_id.nil?
+      receiver = GetStartedReceiver.new(user)
+      receiver.intro_and_request_permissions
+    elsif item['optin']
+      route_optin(user, item)
+    elsif item['postback']
+      route_postback(user, item)
+    elsif item['message'] && item['message']['quick_reply']
+      route_postback(user, item, item['message']['quick_reply']['payload'])
+    elsif item['message']
+      AbstractSender.repeat_last_message(user)
+    end
   end
 
-  def route_postback(item, payload=nil)
-    user = item['sender']['id']
+  def route_postback(user, item, payload=nil)
     payload = item['postback']['payload'] if payload.nil?
     payload = JSON.parse(payload).deep_symbolize_keys
     receiver = Object.const_get(payload[:receiver]).new(user, payload[:data])
     receiver.send(payload[:method].to_sym)
   end
 
-  def route_optin(item)
-    user = item['sender']['id']
+  def route_optin(user, item)
     payload = item['optin']['ref']
     sender = MessageSender.new(user)
     sender.set_message("You did the optin! Wow! #{payload}")
-    sender.deliver!
+          .deliver!
+  end
+
+  def load_user(sender_id)
+    User.find_or_create_by(fb_messenger_id: sender_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,21 @@
+class User < ApplicationRecord
+  
+end
+
+# == Schema Information
+#
+# Table name: users
+#
+#  id                :integer          not null, primary key
+#  fb_messenger_id   :string
+#  fb_profile_id     :string
+#  ignore            :boolean          default(FALSE)
+#  last_message_sent :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  fb_messenger_id_idx  (fb_messenger_id)
+#  fb_profile_id_idx    (fb_profile_id)
+#

--- a/app/services/receivers/abstract_receiver.rb
+++ b/app/services/receivers/abstract_receiver.rb
@@ -1,6 +1,6 @@
 class AbstractReceiver
 
-  def initialize(user, data)
+  def initialize(user, data={})
     @user = user
     @data = data
   end

--- a/app/services/receivers/get_started_receiver.rb
+++ b/app/services/receivers/get_started_receiver.rb
@@ -1,40 +1,14 @@
 class GetStartedReceiver < AbstractReceiver
 
-  def get_started
+  def intro_and_request_permissions
     sender = MessageSender.new(@user)
-    sender.set_message('Hi, how are you :)')
-          .add_reply(title: 'Play a game of Pong!',
+    sender.set_message('Hi, how are you, I need your permissions!')
+          .add_reply(title: 'Ok!',
+                     payload: link_receiver(self, :ping, {count: 1}))
+          .add_reply(title: 'No!',
                      payload: link_receiver(self, :ping, {count: 1}))
           .deliver!
   end
 
-  def ping
-    count = @data[:count]
-    sender = MessageSender.new(@user)
-    sender.set_message("Ping! #{count}")
-          .add_reply(title: 'Pong back?',
-                     payload: link_receiver(self, :pong, {count: count + 1}))
-          .deliver!
-  end
-
-  def pong
-    count = @data[:count]
-    sender = MessageSender.new(@user)
-    sender.set_message("Pong! #{count}")
-          .add_reply(title: 'Ping back?',
-                     payload: link_receiver(self, :ping, {count: count + 1}))
-
-    if count >= 9
-      sender.add_reply(title: "Show funny image?",
-                       payload: link_receiver(self, :funny_image))
-    end
-    sender.deliver!
-  end
-
-  def funny_image
-    sender = MediaSender.new(@user)
-    sender.set_image('https://media.giphy.com/media/11LtzfNXmCQQ80/giphy.gif')
-          .deliver!
-  end
 
 end

--- a/app/services/senders/card_sender.rb
+++ b/app/services/senders/card_sender.rb
@@ -1,15 +1,15 @@
 class CardSender < AbstractSender
 
   # How to use:
-  # sender = CardSender.new(recipient)
+  # sender = CardSender.new(user)
   # sender.add_card(title: 'Invite a friend!', image_url: 'http... or name of image in assets folder')
   #       .add_url_button(title: 'Invite!', url: 'http...', webview_size: 'tall')
   #       .add_share_button
   # sender.add_card(...)
   # sender.deliver!
 
-  def initialize(recipient)
-    super(recipient)
+  def initialize(user)
+    super(user)
     @elements = []
   end
 

--- a/app/services/senders/media_sender.rb
+++ b/app/services/senders/media_sender.rb
@@ -1,7 +1,7 @@
 class MediaSender < AbstractSender
 
   # How to use (same for set_audio/video/file, etc)
-  # sender = MediaSender.new(recipient)
+  # sender = MediaSender.new(user)
   # sender.set_image('https://imageurl.com/image.png')
   #        OR
   # sender.set_image('israel.png')

--- a/app/services/senders/message_sender.rb
+++ b/app/services/senders/message_sender.rb
@@ -2,20 +2,20 @@ class MessageSender < AbstractSender
 
   # How to use:
   # To send just a message:
-  # sender = MessageSender.new(recipient)
+  # sender = MessageSender.new(user)
   # sender.set_message('Hi mom')
   #       .deliver!
   #
   # To send a message with quick replies:
-  # sender = MessageSender.new(recipient)
+  # sender = MessageSender.new(user)
   # sender.set_message('Pick one')
   #       .add_reply(title: 'exercise', payload: 'one')
   #       .add_reply(title: 'study', payload: 'two')
   #       .add_reply(title: 'eat', payload: 'three')
   #       .deliver!
 
-  def initialize(recipient)
-    super(recipient)
+  def initialize(user)
+    super(user)
     @message = nil
     @replies = []
   end

--- a/app/services/senders/prompt_sender.rb
+++ b/app/services/senders/prompt_sender.rb
@@ -1,14 +1,14 @@
 class PromptSender < AbstractSender
 
   # How to use:
-  # sender = PromptSender.new(recipient)
+  # sender = PromptSender.new(user)
   # sender.set_message('Hi mom')
   #       .add_url_button(title: 'Click me', url: 'https://google.com', ...)
   #       .add_share_button
   #       .deliver!
 
-  def initialize(recipient)
-    super(recipient)
+  def initialize(user)
+    super(user)
     @message = nil
     @buttons = []
   end

--- a/db/migrate/20161123184144_create_users.rb
+++ b/db/migrate/20161123184144_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :users do |t|
+      t.string :fb_messenger_id
+      t.string :fb_profile_id
+      t.boolean :ignore, default: false
+      t.string :last_message_sent
+      t.timestamps
+    end
+
+    add_index :users, :fb_messenger_id, name: 'fb_messenger_id_idx'
+    add_index :users, :fb_profile_id, name: 'fb_profile_id_idx'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20161123184144) do
+
+  create_table "users", force: :cascade do |t|
+    t.string   "fb_messenger_id"
+    t.string   "fb_profile_id"
+    t.boolean  "ignore",            default: false
+    t.string   "last_message_sent"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.index ["fb_messenger_id"], name: "fb_messenger_id_idx"
+    t.index ["fb_profile_id"], name: "fb_profile_id_idx"
+  end
+
+end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,48 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'routes'                  => 'false',
+      'position_in_routes'      => 'before',
+      'position_in_class'       => 'after',
+      'position_in_test'        => 'before',
+      'position_in_fixture'     => 'before',
+      'position_in_factory'     => 'before',
+      'position_in_serializer'  => 'before',
+      'show_foreign_keys'       => 'true',
+      'show_indexes'            => 'true',
+      'simple_indexes'          => 'false',
+      'model_dir'               => 'app/models',
+      'root_dir'                => '',
+      'include_version'         => 'false',
+      'require'                 => '',
+      'exclude_tests'           => 'true',
+      'exclude_fixtures'        => 'true',
+      'exclude_factories'       => 'true',
+      'exclude_serializers'     => 'true',
+      'exclude_scaffolds'       => 'true',
+      'exclude_controllers'     => 'true',
+      'exclude_helpers'         => 'true',
+      'ignore_model_sub_dir'    => 'false',
+      'ignore_columns'          => nil,
+      'ignore_routes'           => nil,
+      'ignore_unknown_models'   => 'false',
+      'hide_limit_column_types' => 'integer,boolean',
+      'skip_on_db_migrate'      => 'false',
+      'format_bare'             => 'true',
+      'format_rdoc'             => 'false',
+      'format_markdown'         => 'false',
+      'sort'                    => 'false',
+      'force'                   => 'false',
+      'trace'                   => 'false',
+      'wrapper_open'            => nil,
+      'wrapper_close'           => nil
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
4 major changes in this PR:

1. Added the little "typing" bubble and a small delay whenever the bot sends a message. This helps convey to the user that they are having a conversation with the bot, much more than when the both just instantly replies.

2. Updated routing to support the flow where the bot asks for the user's Facebook profile (to get their friends), the bot will continue to ask them until they accept (of course they have the option to just not use the bot too). 

3. Updated routing so that when a user types a normal text message (instead of using a quick reply, postback button, or webview) the last message that the bot sent to them will be sent again so that they realize they have to choose one of those options. This is really should never happen in the normal use case, it's just here to prevent someone getting stuck in a deadend because they typed something.

4. Also added the ability to ignore user text messages (useful in situations where you want to send multple messages and not have the user break the bot's flow of control). Again, this is just a failsafe and really shouldn't ever impact the user experience.

5. Added initial User model fields to support the getting their Facebook profile id and the changes above.