### PR TITLE
Support for dummy users

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -47,8 +47,10 @@ class InvitesController < ApplicationController
       Activity.create({user: @current_user,
                        text: "#{@current_user.first_name} made a new event: #{params[:what]}!",
                        time: params[:when], location: params[:where]})
-      receiver = GetStartedReceiver.new(@current_user)
-      receiver.send_invite_card(invite)
+      unless session[:force_mode]
+        receiver = GetStartedReceiver.new(@current_user)
+        receiver.send_invite_card(invite)
+      end
       render 'users/login_success', layout: 'bare'
     end
   end
@@ -56,6 +58,11 @@ class InvitesController < ApplicationController
   private
 
   def load_invite_user(route)
+    if session[:force_mode]
+      @current_user = User.find(session[:current_user])
+      @invite = Invitation.find(params[:id])
+      return
+    end
     return if dev_mode?
     data = Rack::Utils.parse_nested_query(params[:state]).deep_symbolize_keys
     @invite = Invitation.find(data[:invite_id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,13 @@
 class UsersController < ApplicationController
   layout 'webview'
-  before_action :load_current_user, except: [:login_success, :newsfeed]
+  before_action :load_current_user, except: [:force_login, :login_success, :newsfeed]
   before_action :load_user, only: [:activity, :goals, :interests, :availability]
+
+  def force_login
+    session[:force_mode] = true
+    session[:current_user] = User.where(first_name: params[:name].capitalize).first.id
+    redirect_to user_newsfeed_url
+  end
 
   def login_success
     load_fb_user('/login_success', true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   get 'messages/webhook', to: 'messages#webhook'
   post 'messages/webhook', to: 'messages#incoming'
 
+  # Force login endpoint
+  get '/force_login/:name', to: 'users#force_login'
+
   # Facebook oauth endpoint
   get '/login_success', to: 'users#login_success'
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,40 +6,84 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# israel = {
-#   fb_messenger_id: "1249671568407617",
-#   fb_profile_id: "332335830458707",
-#   picture_url: "https://scontent.xx.fbcdn.net/v/t1.0-1/p200x200/12096030_100829086942717_8527138496669322222_n.jpg?oh=a065de481cf012d08f9ee8e991d00373&oe=58B20170",
-#   first_name: "Israel",
-#   full_name: "Israel Madueme",
-# }
-#
-# ashely = {
-#   fb_messenger_id: "1394801870531711",
-#   fb_profile_id: "10154276433464531",
-#   picture_url: "https://scontent.xx.fbcdn.net/v/t1.0-1/p200x200/12813976_10153621234204531_5170130368261047714_n.jpg?oh=42bad2ec64421686180cf2728aa43de8&oe=58B3E5D8",
-#   first_name: "Ashley",
-#   full_name: "Ashley Wong",
-# }
-#
-# jeanine = {
-#   fb_messenger_id: "1246256218780554",
-#   fb_profile_id: "196377360819352",
-#   picture_url: "https://scontent.xx.fbcdn.net/v/t1.0-1/p200x200/15338815_211470649310023_8742677445102530523_n.jpg?oh=725002d9093448932ab07d53e191bab3&oe=58C6B6B5",
-#   first_name: "Jeanine",
-#   full_name: "Jeanine Huang",
-# }
-#
-# # Create users
-# israel = User.create israel
-# ashely = User.create ashely
-# jeanine = User.create jeanine
-#
-# # Create friendships
-# Friendship.create({user_id: israel.id, friend_id: jeanine.id})
-# Friendship.create({user_id: israel.id, friend_id: ashely.id})
-# Friendship.create({user_id: ashely.id, friend_id: israel.id})
-# Friendship.create({user_id: ashely.id, friend_id: jeanine.id})
-# Friendship.create({user_id: jeanine.id, friend_id: israel.id})
-# Friendship.create({user_id: jeanine.id, friend_id: ashely.id})
+israel = {
+  fb_messenger_id: "1249671568407617",
+  picture_url: "https://scontent.xx.fbcdn.net/v/t1.0-1/p200x200/12096030_100829086942717_8527138496669322222_n.jpg?oh=a065de481cf012d08f9ee8e991d00373&oe=58B20170",
+  first_name: "Israel",
+  full_name: "Israel Madueme",
+}
 
+ashely = {
+  fb_messenger_id: "1394801870531711",
+  picture_url: "https://scontent.xx.fbcdn.net/v/t1.0-1/p200x200/12813976_10153621234204531_5170130368261047714_n.jpg?oh=42bad2ec64421686180cf2728aa43de8&oe=58B3E5D8",
+  first_name: "Ashley",
+  full_name: "Ashley Wong",
+}
+
+jeanine = {
+  fb_messenger_id: "1246256218780554",
+  picture_url: "https://scontent.xx.fbcdn.net/v/t1.0-1/p200x200/15338815_211470649310023_8742677445102530523_n.jpg?oh=725002d9093448932ab07d53e191bab3&oe=58C6B6B5",
+  first_name: "Jeanine",
+  full_name: "Jeanine Huang",
+}
+
+nikita = {
+  picture_url: "https://scontent-atl3-1.xx.fbcdn.net/v/t1.0-1/p160x160/15220114_10211266959890388_547915919189966138_n.jpg?oh=6b73cd83c356beffeb96d2534b2fdae1&oe=58F83E63",
+  first_name: "Nikita",
+  full_name: "Nikita Bokil",
+}
+
+renzo = {
+  picture_url: "https://scontent-atl3-1.xx.fbcdn.net/v/t1.0-1/c36.0.160.160/p160x160/12360157_10153759512262380_7448695663472232283_n.jpg?oh=f1fb6b18b55cfcd2789d69cb71735fb8&oe=58F0BB4C",
+  first_name: "Renzo",
+  full_name: "Renzo Bautista ",
+}
+
+hanson = {
+  picture_url: "https://scontent-atl3-1.xx.fbcdn.net/v/t1.0-1/p160x160/12923344_1166766580022458_1493336177519295152_n.jpg?oh=d44217730f303b89e473edc90874b865&oe=58F0745F",
+  first_name: "Hanson",
+  full_name: "Hanson Zeng",
+}
+
+jen = {
+  picture_url: "https://scontent-atl3-1.xx.fbcdn.net/v/t1.0-1/c0.0.160.160/p160x160/1928337_1017044978316719_2759336424760058839_n.jpg?oh=689b329195cf616939f071c9d46d51c6&oe=58AE6651",
+  first_name: "Jennifer",
+  full_name: "Jennifer Han",
+}
+
+# Create users
+israel = User.create israel
+ashely = User.create ashely
+jeanine = User.create jeanine
+nikita = User.create nikita
+renzo = User.create renzo
+hanson = User.create hanson
+jen = User.create jen
+
+group1 = [jeanine, nikita, renzo, jen]
+group2 = [ashely, renzo, hanson, jen]
+
+# Create friendships
+
+group1.each do |person|
+  group1.each do |other|
+    unless person.id == other.id
+      Friendship.create({user_id: person.id, friend_id: other.id})
+    end
+  end
+end
+
+group2.each do |person|
+  group2.each do |other|
+    unless person.id == other.id
+      Friendship.create({user_id: person.id, friend_id: other.id})
+    end
+  end
+end
+
+Friendship.create({user_id: israel.id, friend_id: jeanine.id})
+Friendship.create({user_id: israel.id, friend_id: ashely.id})
+Friendship.create({user_id: ashely.id, friend_id: israel.id})
+Friendship.create({user_id: ashely.id, friend_id: jeanine.id})
+Friendship.create({user_id: jeanine.id, friend_id: israel.id})
+Friendship.create({user_id: jeanine.id, friend_id: ashely.id})


### PR DESCRIPTION
- Added an endpoint to force logging in as any user based on first name. 
- Added seed data for some dummy users. Note that when logging in with a "real" user, real data will take the place of the dummy data.
- Updated the methods that load user session to support force login.